### PR TITLE
Alwin

### DIFF
--- a/src/common/mapStringToEnum.ts
+++ b/src/common/mapStringToEnum.ts
@@ -118,8 +118,10 @@ export function mapUserRoleToEnum(status: string): UserRoleEnum {
       return UserRoleEnum.CORPORATE;
     case 'administrator':
       return UserRoleEnum.ADMINISTRATOR;
-    default:
+    case 'Job_seeker':
       return UserRoleEnum.JOBSEEKER;
+    default:
+      return null;
   }
 }
 


### PR DESCRIPTION
Changed default case to null instead of job seeker, this should solve the issue that user will log in as job seeker when no role is specified